### PR TITLE
Element type fix - Revert C# 6 features

### DIFF
--- a/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/AbstractFamilyInstance.cs
@@ -83,7 +83,7 @@ namespace Revit.Elements
                 DocumentManager.Regenerate();
                 var pos = InternalFamilyInstance.Location as Autodesk.Revit.DB.LocationPoint;
                 TransactionManager.Instance.TransactionTaskDone();
-                return pos?.Point.ToPoint();
+                return pos != null ? pos.Point.ToPoint() : null;
             }
         }
 

--- a/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
+++ b/src/Libraries/RevitNodes/Elements/FamilyInstance.cs
@@ -309,12 +309,12 @@ namespace Revit.Elements
         {
             if (familyType == null)
             {
-                throw new ArgumentNullException(nameof(familyType));
+                throw new ArgumentNullException("familyType");
             } 
             
             if (point == null)
             {
-                throw new ArgumentNullException(nameof(point));
+                throw new ArgumentNullException("point");
             }
 
             return new FamilyInstance(familyType.InternalFamilySymbol, point.ToXyz());
@@ -334,15 +334,15 @@ namespace Revit.Elements
         {
             if (familyType == null)
             {
-                throw new ArgumentNullException(nameof(familyType));
+                throw new ArgumentNullException("familyType");
             }
             if (face == null)
             {
-                throw new ArgumentNullException(nameof(face));
+                throw new ArgumentNullException("face");
             }
             if (line == null)
             {
-                throw new ArgumentNullException(nameof(line));
+                throw new ArgumentNullException("line");
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
@@ -365,19 +365,19 @@ namespace Revit.Elements
         {
             if (familyType == null)
             {
-                throw new ArgumentNullException(nameof(familyType));
+                throw new ArgumentNullException("familyType");
             }
             if (face == null)
             {
-                throw new ArgumentNullException(nameof(face));
+                throw new ArgumentNullException("face");
             }
             if (location == null)
             {
-                throw new ArgumentNullException(nameof(location));
+                throw new ArgumentNullException("location");
             }
             if (referenceDirection == null)
             {
-                throw new ArgumentNullException(nameof(referenceDirection));
+                throw new ArgumentNullException("referenceDirection");
             }
             var reference = ElementFaceReference.TryGetFaceReference(face);
 
@@ -397,7 +397,7 @@ namespace Revit.Elements
         {
             if (familyType == null)
             {
-                throw new ArgumentNullException(nameof(familyType));
+                throw new ArgumentNullException("familyType");
             }
 
             var pt = Point.ByCoordinates(x, y, z);
@@ -416,7 +416,7 @@ namespace Revit.Elements
         {
             if (familyType == null)
             {
-                throw new ArgumentNullException(nameof(familyType));
+                throw new ArgumentNullException("familyType");
             }
 
             return new FamilyInstance(familyType.InternalFamilySymbol, point.ToXyz(), level.InternalLevel);
@@ -434,7 +434,7 @@ namespace Revit.Elements
         {
             if (familyType == null)
             {
-                throw new ArgumentNullException(nameof(familyType));
+                throw new ArgumentNullException("familyType");
             }
 
             return DocumentManager.Instance
@@ -523,7 +523,7 @@ namespace Revit.Elements
         {
             if (this == null)
             {
-                throw new ArgumentNullException(nameof(degree));
+                throw new ArgumentNullException("degree");
             }
 
             var oldTransform = InternalGetTransform();

--- a/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
+++ b/src/Libraries/RevitNodes/Elements/StucturalFraming.cs
@@ -299,22 +299,22 @@ namespace Revit.Elements
         {
             if (curve == null)
             {
-                throw new ArgumentNullException(nameof(curve));
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new ArgumentNullException(nameof(level));
+                throw new ArgumentNullException("level");
             }
 
             if (upVector == null)
             {
-                throw new ArgumentNullException(nameof(upVector));
+                throw new ArgumentNullException("upVector");
             }
 
             if (structuralFramingType == null)
             {
-                throw new ArgumentNullException(nameof(structuralFramingType));
+                throw new ArgumentNullException("structuralFramingType");
             }            
 
             return new StructuralFraming(curve.ToRevitType(), upVector.ToXyz(), level.InternalLevel,
@@ -332,17 +332,17 @@ namespace Revit.Elements
         {
             if (curve == null)
             {
-                throw new ArgumentNullException(nameof(curve));
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new ArgumentNullException(nameof(level));
+                throw new ArgumentNullException("level");
             }
 
             if (structuralFramingType == null)
             {
-                throw new ArgumentNullException(nameof(structuralFramingType));
+                throw new ArgumentNullException("structuralFramingType");
             }
 
             return new StructuralFraming(curve.ToRevitType(), level.InternalLevel, Autodesk.Revit.DB.Structure.StructuralType.Beam, structuralFramingType.InternalFamilySymbol);
@@ -359,17 +359,17 @@ namespace Revit.Elements
         {
             if (curve == null)
             {
-                throw new ArgumentNullException(nameof(curve));
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new ArgumentNullException(nameof(level));
+                throw new ArgumentNullException("level");
             }
 
             if (structuralFramingType == null)
             {
-                throw new ArgumentNullException(nameof(structuralFramingType));
+                throw new ArgumentNullException("structuralFramingType");
             }
 
             return new StructuralFraming(curve.ToRevitType(), level.InternalLevel, Autodesk.Revit.DB.Structure.StructuralType.Brace, structuralFramingType.InternalFamilySymbol);
@@ -387,17 +387,17 @@ namespace Revit.Elements
         {
             if (curve == null)
             {
-                throw new ArgumentNullException(nameof(curve));
+                throw new ArgumentNullException("curve");
             }
 
             if (level == null)
             {
-                throw new ArgumentNullException(nameof(level));
+                throw new ArgumentNullException("level");
             }
 
             if (structuralColumnType == null)
             {
-                throw new ArgumentNullException(nameof(structuralColumnType));
+                throw new ArgumentNullException("structuralColumnType");
             }
 
             var start = curve.PointAtParameter(0);


### PR DESCRIPTION
### Purpose

@ksobon Good morning and thank you for your contribution to Dynamo for Revit. We need to remove any C# 6 features because Dynamo for Revit 2016 still needs to be build with VS 2013. Sorry about that. This will change when we drop support for 2016.

I made the changes for my testing on 2016 so here you go. Everything looks good so far. Thanks!

### Declarations

Check these if you believe they are true

- [X] The code base is in a better state after this PR
- [X] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [X] The level of testing this PR includes is appropriate
- ~~~User facing strings, if any, are extracted into `*.resx` files~~~
- ~~~Snapshot of UI changes, if any.~~~

### Reviewers

@ksobon 



### FYIs


